### PR TITLE
add simple nodejs image

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,51 @@
+name: build and push nodejs images
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'dockerfiles/nodejs/*'
+  
+  workflow_dispatch:
+
+jobs:
+  matrix-config:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: set-matrix
+        run: |
+          chmod +x matrix-gen.sh
+          matrix_arr=($(./matrix-gen.sh nodejs))
+          echo ${matrix_arr[@]}
+          echo "::set-output name=matrix::{\"include\":[${matrix_arr[@]}]}"
+
+  build-push-images:
+    needs: matrix-config
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{ fromJson(needs.matrix-config.outputs.matrix) }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build & Push
+        uses: docker/build-push-action@v2
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          platforms: linux/amd64, linux/arm64/v8
+          context: .
+          file: ${{ matrix.path }}
+          push: true
+          tags: "packageless/nodejs:${{ matrix.tag }}"

--- a/dockerfiles/nodejs/latest/Dockerfile
+++ b/dockerfiles/nodejs/latest/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:latest
+
+WORKDIR /run/
+
+ENTRYPOINT [ "node" ]


### PR DESCRIPTION
## Proposed Changes
Adds a simple NodeJS container image that can be used to create a NodeJS pim in the packageless-pims repository.
This is just the latest NodeJS version.

## Type of Change
What kind of change to **packageless-containers** is this?

- [ ] Bug Fix
- [x] Feature
- [ ] Documentation

## Checklist
Before the Pull Request can be considered for merging, the following Checklist should have the corresponding fields completed:

- [x] I have read the contributing guidelines
- [x] I have tested my changes locally to ensure that they work as expected

## Expected Behavior
Please include the behavior that is expected when running the image.
`node` command is run and accepts command line options

## Comments
Any further information you want to provide can go here.